### PR TITLE
Replace logging by tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,10 +1256,10 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "hashbrown 0.13.2",
- "log",
  "moka",
  "redis-rate-limiter",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1470,40 +1470,6 @@ dependencies = [
  "serde",
  "ulid",
  "uuid 1.2.2",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2428,12 +2394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,16 +2573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,18 +2586,6 @@ checksum = "6d0586ad318a04c73acdbad33f67969519b5452c80770c4c72059a686da48a7e"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes",
- "rustix",
- "windows-sys",
 ]
 
 [[package]]
@@ -2792,12 +2730,6 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -4070,20 +4002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4408,7 +4326,7 @@ dependencies = [
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
- "sentry-core",
+ "sentry-core 0.29.2",
  "sentry-log",
  "sentry-panic",
  "tokio",
@@ -4424,7 +4342,7 @@ checksum = "45a52d909ea1f5107fe29aa86581da01b88bde811fbde875773237c1596fbab6"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.29.2",
 ]
 
 [[package]]
@@ -4436,7 +4354,7 @@ dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core",
+ "sentry-core 0.29.2",
 ]
 
 [[package]]
@@ -4449,8 +4367,21 @@ dependencies = [
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core",
+ "sentry-core 0.29.2",
  "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
+dependencies = [
+ "once_cell",
+ "rand",
+ "sentry-types 0.27.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4461,7 +4392,7 @@ checksum = "fc43eb7e4e3a444151a0fe8a0e9ce60eabd905dae33d66e257fa26f1b509c1bd"
 dependencies = [
  "once_cell",
  "rand",
- "sentry-types",
+ "sentry-types 0.29.2",
  "serde",
  "serde_json",
 ]
@@ -4473,7 +4404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598aefe14750bcec956adebc8992dd432f4e22c12cd524633963113864aa39b4"
 dependencies = [
  "log",
- "sentry-core",
+ "sentry-core 0.29.2",
 ]
 
 [[package]]
@@ -4483,7 +4414,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccab4fab11e3e63c45f4524bee2e75cde39cdf164cb0b0cbe6ccd1948ceddf66"
 dependencies = [
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.29.2",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea50bcf843510179a7ba41c9fe4d83a8958e9f8adf707ec731ff999297536344"
+dependencies = [
+ "sentry-core 0.27.0",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
+dependencies = [
+ "debugid",
+ "getrandom",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.17",
+ "url",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -5390,6 +5349,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5468,6 +5428,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
+ "parking_lot 0.12.1",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -5842,7 +5803,6 @@ dependencies = [
  "derive_more",
  "dotenv",
  "entities",
- "env_logger",
  "ethers",
  "fdlimit",
  "flume",
@@ -5855,7 +5815,6 @@ dependencies = [
  "http",
  "ipnet",
  "itertools",
- "log",
  "metered",
  "migration",
  "moka",
@@ -5870,6 +5829,7 @@ dependencies = [
  "reqwest",
  "rustc-hash",
  "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "serde_prometheus",
@@ -5881,6 +5841,8 @@ dependencies = [
  "toml 0.6.0",
  "tower",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "ulid",
  "url",
  "uuid 1.2.2",

--- a/deferred-rate-limiter/Cargo.toml
+++ b/deferred-rate-limiter/Cargo.toml
@@ -9,6 +9,6 @@ redis-rate-limiter = { path = "../redis-rate-limiter" }
 
 anyhow = "1.0.68"
 hashbrown = "0.13.2"
-log = "0.4.17"
 moka = { version = "0.9.6", default-features = false, features = ["future"] }
 tokio = "1.24.2"
+tracing = "0.1.37"

--- a/deferred-rate-limiter/src/lib.rs
+++ b/deferred-rate-limiter/src/lib.rs
@@ -1,5 +1,5 @@
 //#![warn(missing_docs)]
-use log::error;
+use tracing::error;
 use moka::future::Cache;
 use redis_rate_limiter::{RedisRateLimitResult, RedisRateLimiter};
 use std::cmp::Eq;

--- a/web3_proxy/Cargo.toml
+++ b/web3_proxy/Cargo.toml
@@ -34,7 +34,6 @@ chrono = "0.4.23"
 counter = "0.5.7"
 derive_more = "0.99.17"
 dotenv = "0.15.0"
-env_logger = "0.10.0"
 ethers = { version = "1.0.2", default-features = false, features = ["rustls", "ws"] }
 fdlimit = "0.2.1"
 flume = "0.10.14"
@@ -47,7 +46,6 @@ hdrhistogram = "7.5.2"
 http = "0.2.8"
 ipnet = "2.7.1"
 itertools = "0.10.5"
-log = "0.4.17"
 metered = { version = "0.9.0", features = ["serialize"] }
 moka = { version = "0.9.6", default-features = false, features = ["future"] }
 notify = "5.0.0"
@@ -60,6 +58,7 @@ regex = "1.7.1"
 reqwest = { version = "0.11.14", default-features = false, features = ["json", "tokio-rustls"] }
 rustc-hash = "1.1.0"
 sentry = { version = "0.29.2", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "rustls", "log", "sentry-log"] }
+sentry-tracing = "0.27.0"
 serde = { version = "1.0.152", features = [] }
 serde_json = { version = "1.0.91", default-features = false, features = ["alloc", "raw_value"] }
 serde_prometheus = "0.1.6"
@@ -69,7 +68,9 @@ tokio = { version = "1.24.2", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["sync"] }
 toml = "0.6.0"
 tower = "0.4.13"
-tower-http = { version = "0.3.5", features = ["cors", "sensitive-headers"] }
+tower-http = { version = "0.3.5", features = ["cors", "sensitive-headers", "trace"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "parking_lot"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 url = "2.3.1"
 uuid = "1.2.2"

--- a/web3_proxy/src/app/mod.rs
+++ b/web3_proxy/src/app/mod.rs
@@ -124,7 +124,7 @@ impl PartialEq for ResponseCacheKey {
 impl Eq for ResponseCacheKey {}
 
 impl Hash for ResponseCacheKey {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.block.as_ref().map(|x| x.hash()).hash(state);
         self.method.hash(state);
@@ -1252,7 +1252,7 @@ impl Web3ProxyApp {
                         &request,
                         Some(request_metadata.clone()),
                         None,
-                        Level::Trace,
+                        Level::TRACE,
                         num,
                     )
                     .await?;

--- a/web3_proxy/src/app/mod.rs
+++ b/web3_proxy/src/app/mod.rs
@@ -31,7 +31,7 @@ use futures::future::join_all;
 use futures::stream::{FuturesUnordered, StreamExt};
 use hashbrown::{HashMap, HashSet};
 use ipnet::IpNet;
-use log::{debug, error, info, trace, warn, Level};
+use tracing::{debug, error, info, trace, warn, Level};
 use metered::{metered, ErrorCount, HitCount, ResponseTime, Throughput};
 use migration::sea_orm::{
     self, ConnectionTrait, Database, DatabaseConnection, EntityTrait, PaginatorTrait,

--- a/web3_proxy/src/app/ws.rs
+++ b/web3_proxy/src/app/ws.rs
@@ -12,7 +12,7 @@ use ethers::prelude::U64;
 use futures::future::AbortHandle;
 use futures::future::Abortable;
 use futures::stream::StreamExt;
-use tracing::{trace, warn};
+use tracing::{instrument, trace, warn};
 use serde_json::json;
 use std::sync::atomic::{self, AtomicUsize};
 use std::sync::Arc;
@@ -20,6 +20,7 @@ use tokio_stream::wrappers::{BroadcastStream, WatchStream};
 
 impl Web3ProxyApp {
     // TODO: #[measure([ErrorCount, HitCount, ResponseTime, Throughput])]
+    #[instrument(level = "trace")]
     pub async fn eth_subscribe<'a>(
         self: &'a Arc<Self>,
         authorization: Arc<Authorization>,

--- a/web3_proxy/src/app/ws.rs
+++ b/web3_proxy/src/app/ws.rs
@@ -12,7 +12,7 @@ use ethers::prelude::U64;
 use futures::future::AbortHandle;
 use futures::future::Abortable;
 use futures::stream::StreamExt;
-use log::{trace, warn};
+use tracing::{trace, warn};
 use serde_json::json;
 use std::sync::atomic::{self, AtomicUsize};
 use std::sync::Arc;

--- a/web3_proxy/src/app_stats.rs
+++ b/web3_proxy/src/app_stats.rs
@@ -81,6 +81,7 @@ impl ProxyResponseStat {
     }
 }
 
+#[derive(Debug)]
 pub struct ProxyResponseHistograms {
     request_bytes: Histogram<u64>,
     response_bytes: Histogram<u64>,
@@ -115,7 +116,7 @@ struct ProxyResponseAggregateKey {
     origin: Option<Origin>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ProxyResponseAggregate {
     frontend_requests: u64,
     backend_requests: u64,

--- a/web3_proxy/src/app_stats.rs
+++ b/web3_proxy/src/app_stats.rs
@@ -6,7 +6,7 @@ use entities::rpc_accounting;
 use entities::sea_orm_active_enums::LogLevel;
 use hashbrown::HashMap;
 use hdrhistogram::{Histogram, RecordError};
-use log::{error, info};
+use tracing::{error, info};
 use migration::sea_orm::{self, ActiveModelTrait, DatabaseConnection, DbErr};
 use std::num::NonZeroU64;
 use std::sync::atomic::Ordering;

--- a/web3_proxy/src/bin/web3_proxy_cli/change_user_address.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/change_user_address.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use argh::FromArgs;
 use entities::user;
 use ethers::types::Address;
-use log::{debug, info};
+use tracing::{debug, info};
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
     QueryFilter,

--- a/web3_proxy/src/bin/web3_proxy_cli/change_user_tier.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/change_user_tier.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use argh::FromArgs;
 use entities::user_tier;
-use log::{debug, info};
+use tracing::{debug, info};
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
     QueryFilter,

--- a/web3_proxy/src/bin/web3_proxy_cli/change_user_tier_by_address.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/change_user_tier_by_address.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use argh::FromArgs;
 use entities::{user, user_tier};
 use ethers::types::Address;
-use log::{debug, info};
+use tracing::{debug, info};
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
     QueryFilter,

--- a/web3_proxy/src/bin/web3_proxy_cli/change_user_tier_by_key.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/change_user_tier_by_key.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use argh::FromArgs;
 use entities::{rpc_key, user, user_tier};
-use log::{debug, info};
+use tracing::{debug, info};
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
     QueryFilter,

--- a/web3_proxy/src/bin/web3_proxy_cli/check_config.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/check_config.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 use std::fs;
 use web3_proxy::config::TopConfig;
 

--- a/web3_proxy/src/bin/web3_proxy_cli/count_users.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/count_users.rs
@@ -1,6 +1,6 @@
 use argh::FromArgs;
 use entities::user;
-use log::info;
+use tracing::info;
 use migration::sea_orm::{self, EntityTrait, PaginatorTrait};
 
 #[derive(FromArgs, PartialEq, Debug, Eq)]

--- a/web3_proxy/src/bin/web3_proxy_cli/create_key.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/create_key.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use argh::FromArgs;
 use entities::{rpc_key, user};
 use ethers::prelude::Address;
-use log::info;
+use tracing::info;
 use migration::sea_orm::{self, ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
 use ulid::Ulid;
 use uuid::Uuid;

--- a/web3_proxy/src/bin/web3_proxy_cli/create_user.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/create_user.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use argh::FromArgs;
 use entities::{rpc_key, user};
 use ethers::prelude::Address;
-use log::info;
+use tracing::info;
 use migration::sea_orm::{self, ActiveModelTrait, TransactionTrait};
 use ulid::Ulid;
 use uuid::Uuid;

--- a/web3_proxy/src/bin/web3_proxy_cli/daemon.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/daemon.rs
@@ -2,7 +2,7 @@
 
 use argh::FromArgs;
 use futures::StreamExt;
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 use num::Zero;
 use tokio::sync::broadcast;
 use web3_proxy::app::{flatten_handle, flatten_handles, Web3ProxyApp};

--- a/web3_proxy/src/bin/web3_proxy_cli/pagerduty.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/pagerduty.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use log::{error, info};
+use tracing::{error, info};
 use pagerduty_rs::{eventsv2async::EventsV2 as PagerdutyAsyncEventsV2, types::Event};
 use web3_proxy::{
     config::TopConfig,

--- a/web3_proxy/src/bin/web3_proxy_cli/rpc_accounting.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/rpc_accounting.rs
@@ -3,7 +3,7 @@ use anyhow::Context;
 use argh::FromArgs;
 use entities::{rpc_accounting, rpc_key, user};
 use ethers::types::Address;
-use log::info;
+use tracing::info;
 use migration::{
     sea_orm::{
         self,

--- a/web3_proxy/src/bin/web3_proxy_cli/sentryd/compare.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/sentryd/compare.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
 use ethers::types::{Block, TxHash, H256};
 use futures::{stream::FuturesUnordered, StreamExt};
-use log::{debug, warn};
+use tracing::{debug, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use web3_proxy::jsonrpc::JsonRpcErrorData;

--- a/web3_proxy/src/bin/web3_proxy_cli/sentryd/simple.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/sentryd/simple.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use super::{SentrydErrorBuilder, SentrydResult};
 use anyhow::Context;
-use log::{debug, trace};
+use tracing::{debug, trace};
 use tokio::time::Instant;
 
 /// GET the url and return an error if it wasn't a success

--- a/web3_proxy/src/bin/web3_proxy_cli/transfer_key.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/transfer_key.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use argh::FromArgs;
 use entities::{rpc_key, user};
 use ethers::types::Address;
-use log::{debug, info};
+use tracing::{debug, info};
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
     QueryFilter,

--- a/web3_proxy/src/bin/web3_proxy_cli/user_export.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/user_export.rs
@@ -1,6 +1,6 @@
 use argh::FromArgs;
 use entities::{rpc_key, user};
-use log::info;
+use tracing::info;
 use migration::sea_orm::{DatabaseConnection, EntityTrait, PaginatorTrait};
 use std::fs::{self, create_dir_all};
 use std::path::Path;

--- a/web3_proxy/src/bin/web3_proxy_cli/user_import.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/user_import.rs
@@ -3,7 +3,7 @@ use argh::FromArgs;
 use entities::{rpc_key, user};
 use glob::glob;
 use hashbrown::HashMap;
-use log::{info, warn};
+use tracing::{info, warn};
 use migration::sea_orm::ActiveValue::NotSet;
 use migration::sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,

--- a/web3_proxy/src/block_number.rs
+++ b/web3_proxy/src/block_number.rs
@@ -4,7 +4,7 @@ use ethers::{
     prelude::{BlockNumber, U64},
     types::H256,
 };
-use log::{trace, warn};
+use tracing::{trace, warn};
 use serde_json::json;
 use std::sync::Arc;
 

--- a/web3_proxy/src/block_number.rs
+++ b/web3_proxy/src/block_number.rs
@@ -4,13 +4,14 @@ use ethers::{
     prelude::{BlockNumber, U64},
     types::H256,
 };
-use tracing::{trace, warn};
+use tracing::{instrument, trace, warn};
 use serde_json::json;
 use std::sync::Arc;
 
 use crate::{frontend::authorization::Authorization, rpcs::connections::Web3Connections};
 
 #[allow(non_snake_case)]
+#[instrument(level = "trace")]
 pub fn block_num_to_U64(block_num: BlockNumber, latest_block: U64) -> U64 {
     match block_num {
         BlockNumber::Earliest => {
@@ -41,7 +42,7 @@ pub fn block_num_to_U64(block_num: BlockNumber, latest_block: U64) -> U64 {
 }
 
 /// modify params to always have a block number and not "latest"
-
+#[instrument(level = "trace")]
 pub async fn clean_block_number(
     authorization: &Arc<Authorization>,
     params: &mut serde_json::Value,
@@ -115,6 +116,7 @@ pub enum BlockNeeded {
     Cache { block_num: U64, cache_errors: bool },
 }
 
+#[instrument(level = "trace")]
 pub async fn block_needed(
     authorization: &Arc<Authorization>,
     method: &str,

--- a/web3_proxy/src/config.rs
+++ b/web3_proxy/src/config.rs
@@ -6,7 +6,7 @@ use argh::FromArgs;
 use ethers::prelude::TxHash;
 use ethers::types::U256;
 use hashbrown::HashMap;
-use tracing::warn;
+use tracing::{instrument, warn};
 use migration::sea_orm::DatabaseConnection;
 use serde::Deserialize;
 use std::sync::Arc;
@@ -227,6 +227,7 @@ impl Web3ConnectionConfig {
     /// Create a Web3Connection from config
     /// TODO: move this into Web3Connection? (just need to make things pub(crate))
     #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "trace")]
     pub async fn spawn(
         self,
         name: String,

--- a/web3_proxy/src/config.rs
+++ b/web3_proxy/src/config.rs
@@ -227,7 +227,7 @@ impl Web3ConnectionConfig {
     /// Create a Web3Connection from config
     /// TODO: move this into Web3Connection? (just need to make things pub(crate))
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(redis_pool))]
     pub async fn spawn(
         self,
         name: String,

--- a/web3_proxy/src/config.rs
+++ b/web3_proxy/src/config.rs
@@ -6,7 +6,7 @@ use argh::FromArgs;
 use ethers::prelude::TxHash;
 use ethers::types::U256;
 use hashbrown::HashMap;
-use log::warn;
+use tracing::warn;
 use migration::sea_orm::DatabaseConnection;
 use serde::Deserialize;
 use std::sync::Arc;

--- a/web3_proxy/src/frontend/authorization.rs
+++ b/web3_proxy/src/frontend/authorization.rs
@@ -16,7 +16,7 @@ use futures::TryFutureExt;
 use hashbrown::HashMap;
 use http::HeaderValue;
 use ipnet::IpNet;
-use log::{error, warn};
+use tracing::{error, warn};
 use migration::sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use parking_lot::Mutex;
 use redis_rate_limiter::redis::AsyncCommands;

--- a/web3_proxy/src/frontend/authorization.rs
+++ b/web3_proxy/src/frontend/authorization.rs
@@ -127,7 +127,7 @@ impl Default for RpcSecretKey {
 }
 
 impl Display for RpcSecretKey {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TODO: do this without dereferencing
         let ulid: Ulid = (*self).into();

--- a/web3_proxy/src/frontend/errors.rs
+++ b/web3_proxy/src/frontend/errors.rs
@@ -11,7 +11,7 @@ use axum::{
 use derive_more::From;
 use http::header::InvalidHeaderValue;
 use ipnet::AddrParseError;
-use log::{trace, warn};
+use tracing::{trace, warn};
 use migration::sea_orm::DbErr;
 use redis_rate_limiter::redis::RedisError;
 use reqwest::header::ToStrError;

--- a/web3_proxy/src/frontend/errors.rs
+++ b/web3_proxy/src/frontend/errors.rs
@@ -11,7 +11,7 @@ use axum::{
 use derive_more::From;
 use http::header::InvalidHeaderValue;
 use ipnet::AddrParseError;
-use tracing::{trace, warn};
+use tracing::{instrument, trace, warn};
 use migration::sea_orm::DbErr;
 use redis_rate_limiter::redis::RedisError;
 use reqwest::header::ToStrError;
@@ -44,6 +44,7 @@ pub enum FrontendErrorResponse {
 }
 
 impl FrontendErrorResponse {
+    #[instrument(level = "trace")]
     pub fn into_response_parts(self) -> (StatusCode, JsonRpcForwardedResponse) {
         match self {
             Self::AccessDenied => {
@@ -272,6 +273,7 @@ impl FrontendErrorResponse {
 }
 
 impl IntoResponse for FrontendErrorResponse {
+    #[instrument(level = "trace")]
     fn into_response(self) -> Response {
         // TODO: include the request id in these so that users can give us something that will point to logs
         // TODO: status code is in the jsonrpc response and is also the first item in the tuple. DRY
@@ -281,6 +283,7 @@ impl IntoResponse for FrontendErrorResponse {
     }
 }
 
+#[instrument(level = "trace")]
 pub async fn handler_404() -> Response {
     FrontendErrorResponse::NotFound.into_response()
 }

--- a/web3_proxy/src/frontend/mod.rs
+++ b/web3_proxy/src/frontend/mod.rs
@@ -14,7 +14,7 @@ use axum::{
     Extension, Router,
 };
 use http::header::AUTHORIZATION;
-use log::info;
+use tracing::info;
 use moka::future::Cache;
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/web3_proxy/src/frontend/mod.rs
+++ b/web3_proxy/src/frontend/mod.rs
@@ -14,7 +14,7 @@ use axum::{
     Extension, Router,
 };
 use http::header::AUTHORIZATION;
-use tracing::info;
+use tracing::{info, instrument};
 use moka::future::Cache;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -22,7 +22,7 @@ use std::{iter::once, time::Duration};
 use tower_http::cors::CorsLayer;
 use tower_http::sensitive_headers::SetSensitiveRequestHeadersLayer;
 
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum FrontendResponseCaches {
     Status,
 }
@@ -32,6 +32,7 @@ pub type FrontendResponseCache =
     Cache<FrontendResponseCaches, Arc<serde_json::Value>, hashbrown::hash_map::DefaultHashBuilder>;
 
 /// Start the frontend server.
+#[instrument(level = "trace")]
 pub async fn serve(port: u16, proxy_app: Arc<Web3ProxyApp>) -> anyhow::Result<()> {
     // setup caches for whatever the frontend needs
     // TODO: a moka cache is probably way overkill for this.

--- a/web3_proxy/src/frontend/rpc_proxy_http.rs
+++ b/web3_proxy/src/frontend/rpc_proxy_http.rs
@@ -12,11 +12,13 @@ use axum_client_ip::ClientIp;
 use axum_macros::debug_handler;
 use itertools::Itertools;
 use std::sync::Arc;
+use tracing::{instrument};
 
 /// POST /rpc -- Public entrypoint for HTTP JSON-RPC requests. Web3 wallets use this.
 /// Defaults to rate limiting by IP address, but can also read the Authorization header for a bearer token.
 /// If possible, please use a WebSocket instead.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn proxy_web3_rpc(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -27,6 +29,7 @@ pub async fn proxy_web3_rpc(
 }
 
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn fastest_proxy_web3_rpc(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -39,6 +42,7 @@ pub async fn fastest_proxy_web3_rpc(
 }
 
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn versus_proxy_web3_rpc(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -48,6 +52,7 @@ pub async fn versus_proxy_web3_rpc(
     _proxy_web3_rpc(app, ip, origin, payload, ProxyMode::Versus).await
 }
 
+#[instrument(level = "trace")]
 async fn _proxy_web3_rpc(
     app: Arc<Web3ProxyApp>,
     ClientIp(ip): ClientIp,
@@ -89,6 +94,7 @@ async fn _proxy_web3_rpc(
 /// Can optionally authorized based on origin, referer, or user agent.
 /// If possible, please use a WebSocket instead.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn proxy_web3_rpc_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -112,6 +118,7 @@ pub async fn proxy_web3_rpc_with_key(
 }
 
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn fastest_proxy_web3_rpc_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -135,6 +142,7 @@ pub async fn fastest_proxy_web3_rpc_with_key(
 }
 
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn versus_proxy_web3_rpc_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -158,6 +166,7 @@ pub async fn versus_proxy_web3_rpc_with_key(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[instrument(level = "trace")]
 async fn _proxy_web3_rpc_with_key(
     app: Arc<Web3ProxyApp>,
     ClientIp(ip): ClientIp,

--- a/web3_proxy/src/frontend/rpc_proxy_http.rs
+++ b/web3_proxy/src/frontend/rpc_proxy_http.rs
@@ -18,7 +18,7 @@ use tracing::{instrument};
 /// Defaults to rate limiting by IP address, but can also read the Authorization header for a bearer token.
 /// If possible, please use a WebSocket instead.
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn proxy_web3_rpc(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -29,7 +29,7 @@ pub async fn proxy_web3_rpc(
 }
 
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn fastest_proxy_web3_rpc(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -42,7 +42,7 @@ pub async fn fastest_proxy_web3_rpc(
 }
 
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn versus_proxy_web3_rpc(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -94,7 +94,7 @@ async fn _proxy_web3_rpc(
 /// Can optionally authorized based on origin, referer, or user agent.
 /// If possible, please use a WebSocket instead.
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn proxy_web3_rpc_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -118,7 +118,7 @@ pub async fn proxy_web3_rpc_with_key(
 }
 
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn fastest_proxy_web3_rpc_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -142,7 +142,7 @@ pub async fn fastest_proxy_web3_rpc_with_key(
 }
 
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn versus_proxy_web3_rpc_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,

--- a/web3_proxy/src/frontend/rpc_proxy_ws.rs
+++ b/web3_proxy/src/frontend/rpc_proxy_ws.rs
@@ -47,7 +47,7 @@ pub enum ProxyMode {
 /// Public entrypoint for WebSocket JSON-RPC requests.
 /// Queries a single server at a time
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn websocket_handler(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -60,7 +60,7 @@ pub async fn websocket_handler(
 /// Public entrypoint for WebSocket JSON-RPC requests that uses all synced servers.
 /// Queries all synced backends with every request! This might get expensive!
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn fastest_websocket_handler(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -75,7 +75,7 @@ pub async fn fastest_websocket_handler(
 /// Public entrypoint for WebSocket JSON-RPC requests that uses all synced servers.
 /// Queries **all** backends with every request! This might get expensive!
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn versus_websocket_handler(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -123,7 +123,7 @@ async fn _websocket_handler(
 /// Rate limit and billing based on the api key in the url.
 /// Can optionally authorized based on origin, referer, or user agent.
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn websocket_handler_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -147,7 +147,7 @@ pub async fn websocket_handler_with_key(
 }
 
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn fastest_websocket_handler_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,
@@ -172,7 +172,7 @@ pub async fn fastest_websocket_handler_with_key(
 }
 
 #[debug_handler]
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(ip))]
 pub async fn versus_websocket_handler_with_key(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ip: ClientIp,

--- a/web3_proxy/src/frontend/rpc_proxy_ws.rs
+++ b/web3_proxy/src/frontend/rpc_proxy_ws.rs
@@ -27,7 +27,7 @@ use futures::{
 use handlebars::Handlebars;
 use hashbrown::HashMap;
 use http::StatusCode;
-use log::{error, info, trace, warn};
+use tracing::{error, info, trace, warn};
 use serde_json::json;
 use serde_json::value::to_raw_value;
 use std::sync::Arc;

--- a/web3_proxy/src/frontend/status.rs
+++ b/web3_proxy/src/frontend/status.rs
@@ -9,9 +9,11 @@ use axum::{http::StatusCode, response::IntoResponse, Extension, Json};
 use axum_macros::debug_handler;
 use serde_json::json;
 use std::sync::Arc;
+use tracing::{instrument};
 
 /// Health check page for load balancers to use.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn health(Extension(app): Extension<Arc<Web3ProxyApp>>) -> impl IntoResponse {
     // TODO: add a check that we aren't shutting down
     if app.balanced_rpcs.synced() {
@@ -25,6 +27,7 @@ pub async fn health(Extension(app): Extension<Arc<Web3ProxyApp>>) -> impl IntoRe
 ///
 /// TODO: replace this with proper stats and monitoring
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn status(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     Extension(response_cache): Extension<FrontendResponseCache>,

--- a/web3_proxy/src/frontend/users.rs
+++ b/web3_proxy/src/frontend/users.rs
@@ -26,7 +26,7 @@ use hashbrown::HashMap;
 use http::{HeaderValue, StatusCode};
 use ipnet::IpNet;
 use itertools::Itertools;
-use log::{debug, warn};
+use tracing::{debug, warn};
 use migration::sea_orm::prelude::Uuid;
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, PaginatorTrait, QueryFilter,

--- a/web3_proxy/src/frontend/users.rs
+++ b/web3_proxy/src/frontend/users.rs
@@ -26,7 +26,7 @@ use hashbrown::HashMap;
 use http::{HeaderValue, StatusCode};
 use ipnet::IpNet;
 use itertools::Itertools;
-use tracing::{debug, warn};
+use tracing::{debug, instrument, warn};
 use migration::sea_orm::prelude::Uuid;
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, PaginatorTrait, QueryFilter,
@@ -59,6 +59,7 @@ use ulid::Ulid;
 /// It is a better UX to just click "login with ethereum" and have the account created if it doesn't exist.
 /// We can prompt for an email and and payment after they log in.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_login_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ClientIp(ip): ClientIp,
@@ -176,6 +177,7 @@ pub struct PostLogin {
 /// It is recommended to save the returned bearer token in a cookie.
 /// The bearer token can be used to authenticate other requests, such as getting the user's stats or modifying the user's profile.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_login_post(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     ClientIp(ip): ClientIp,
@@ -385,6 +387,7 @@ pub async fn user_login_post(
 
 /// `POST /user/logout` - Forget the bearer token in the `Authentication` header.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_logout_post(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -429,6 +432,7 @@ pub async fn user_logout_post(
 ///
 /// TODO: this will change as we add better support for secondary users.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer_token)): TypedHeader<Authorization<Bearer>>,
@@ -446,6 +450,7 @@ pub struct UserPost {
 
 /// `POST /user` -- modify the account connected to the bearer token in the `Authentication` header.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_post(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer_token)): TypedHeader<Authorization<Bearer>>,
@@ -492,6 +497,7 @@ pub async fn user_post(
 /// TODO: one key per request? maybe /user/balance/:rpc_key?
 /// TODO: this will change as we add better support for secondary users.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_balance_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -509,6 +515,7 @@ pub async fn user_balance_get(
 /// TODO: one key per request? maybe /user/balance/:rpc_key?
 /// TODO: this will change as we add better support for secondary users.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_balance_post(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -522,6 +529,7 @@ pub async fn user_balance_post(
 ///
 /// TODO: one key per request? maybe /user/keys/:rpc_key?
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn rpc_keys_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -552,6 +560,7 @@ pub async fn rpc_keys_get(
 
 /// `DELETE /user/keys` -- Use a bearer token to delete an existing key.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn rpc_keys_delete(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -583,6 +592,7 @@ pub struct UserKeyManagement {
 
 /// `POST /user/keys` or `PUT /user/keys` -- Use a bearer token to create or update an existing key.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn rpc_keys_management(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -754,6 +764,7 @@ pub async fn rpc_keys_management(
 
 /// `GET /user/revert_logs` -- Use a bearer token to get the user's revert logs.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_revert_logs_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
@@ -824,6 +835,7 @@ pub async fn user_revert_logs_get(
 
 /// `GET /user/stats/aggregate` -- Public endpoint for aggregate stats such as bandwidth used and methods requested.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_stats_aggregated_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     bearer: Option<TypedHeader<Authorization<Bearer>>>,
@@ -844,6 +856,7 @@ pub async fn user_stats_aggregated_get(
 ///
 /// TODO: this will change as we add better support for secondary users.
 #[debug_handler]
+#[instrument(level = "trace")]
 pub async fn user_stats_detailed_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
     bearer: Option<TypedHeader<Authorization<Bearer>>>,

--- a/web3_proxy/src/jsonrpc.rs
+++ b/web3_proxy/src/jsonrpc.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::value::{to_raw_value, RawValue};
 use std::fmt;
+use std::fmt::Debug;
+use tracing::{instrument};
 
 // this is used by serde
 #[allow(dead_code)]
@@ -42,6 +44,7 @@ pub enum JsonRpcRequestEnum {
 }
 
 impl<'de> Deserialize<'de> for JsonRpcRequestEnum {
+    #[instrument(level = "trace")]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -176,6 +179,7 @@ pub struct JsonRpcForwardedResponse {
 }
 
 impl JsonRpcRequest {
+    #[instrument(level = "trace")]
     pub fn num_bytes(&self) -> usize {
         // TODO: not sure how to do this without wasting a ton of allocations
         serde_json::to_string(self)
@@ -185,6 +189,7 @@ impl JsonRpcRequest {
 }
 
 impl JsonRpcForwardedResponse {
+    #[instrument(level = "trace")]
     pub fn from_anyhow_error(
         err: anyhow::Error,
         code: Option<i64>,
@@ -216,6 +221,7 @@ impl JsonRpcForwardedResponse {
         }
     }
 
+    #[instrument(level = "trace")]
     pub fn from_response(partial_response: Box<RawValue>, id: Box<RawValue>) -> Self {
         JsonRpcForwardedResponse {
             jsonrpc: "2.0".to_string(),
@@ -226,6 +232,7 @@ impl JsonRpcForwardedResponse {
         }
     }
 
+    #[instrument(level = "trace")]
     pub fn from_value(partial_response: serde_json::Value, id: Box<RawValue>) -> Self {
         let partial_response =
             to_raw_value(&partial_response).expect("Value to RawValue should always work");
@@ -238,6 +245,7 @@ impl JsonRpcForwardedResponse {
         }
     }
 
+    #[instrument(level = "trace")]
     pub fn from_ethers_error(e: ProviderError, id: Box<RawValue>) -> anyhow::Result<Self> {
         // TODO: move turning ClientError into json to a helper function?
         let code;
@@ -297,6 +305,7 @@ impl JsonRpcForwardedResponse {
         })
     }
 
+    #[instrument(level = "trace")]
     pub fn try_from_response_result(
         result: Result<Box<RawValue>, ProviderError>,
         id: Box<RawValue>,
@@ -307,6 +316,7 @@ impl JsonRpcForwardedResponse {
         }
     }
 
+    #[instrument(level = "trace")]
     pub fn num_bytes(&self) -> usize {
         // TODO: not sure how to do this without wasting a ton of allocations
         serde_json::to_string(self)

--- a/web3_proxy/src/jsonrpc.rs
+++ b/web3_proxy/src/jsonrpc.rs
@@ -44,7 +44,7 @@ pub enum JsonRpcRequestEnum {
 }
 
 impl<'de> Deserialize<'de> for JsonRpcRequestEnum {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/web3_proxy/src/metered/jsonrpc_error_count.rs
+++ b/web3_proxy/src/metered/jsonrpc_error_count.rs
@@ -59,7 +59,7 @@ impl<C: Counter + Debug> Clear for JsonRpcErrorCount<C> {
 impl<C: Counter> Deref for JsonRpcErrorCount<C> {
     type Target = C;
 
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/web3_proxy/src/metered/provider_error_count.rs
+++ b/web3_proxy/src/metered/provider_error_count.rs
@@ -1,5 +1,6 @@
 //! A module providing the `JsonRpcErrorCount` metric.
 
+use std::fmt::Debug;
 use ethers::providers::ProviderError;
 use metered::metric::{Advice, Enter, OnResult};
 use metered::{
@@ -9,6 +10,7 @@ use metered::{
 };
 use serde::Serialize;
 use std::ops::Deref;
+use tracing::{instrument};
 
 /// A metric counting how many times an expression typed std `Result` as
 /// returned an `Err` variant.
@@ -21,15 +23,16 @@ use std::ops::Deref;
 #[derive(Clone, Default, Debug, Serialize)]
 pub struct ProviderErrorCount<C: Counter = AtomicInt<u64>>(pub C);
 
-impl<C: Counter, T> Metric<Result<T, ProviderError>> for ProviderErrorCount<C> {}
+impl<C: Counter + Debug, T: Debug> Metric<Result<T, ProviderError>> for ProviderErrorCount<C> {}
 
-impl<C: Counter> Enter for ProviderErrorCount<C> {
+impl<C: Counter + Debug> Enter for ProviderErrorCount<C> {
     type E = ();
     fn enter(&self) {}
 }
 
-impl<C: Counter, T> OnResult<Result<T, ProviderError>> for ProviderErrorCount<C> {
+impl<C: Counter + Debug, T: Debug> OnResult<Result<T, ProviderError>> for ProviderErrorCount<C> {
     /// Unlike the default ErrorCount, this one does not increment for internal jsonrpc errors
+    #[instrument(level = "trace")]
     fn on_result(&self, _: (), r: &Result<T, ProviderError>) -> Advice {
         match r {
             Ok(_) => {}
@@ -43,6 +46,7 @@ impl<C: Counter, T> OnResult<Result<T, ProviderError>> for ProviderErrorCount<C>
 }
 
 impl<C: Counter> Clear for ProviderErrorCount<C> {
+    #[instrument(level = "trace")]
     fn clear(&self) {
         self.0.clear()
     }
@@ -51,6 +55,7 @@ impl<C: Counter> Clear for ProviderErrorCount<C> {
 impl<C: Counter> Deref for ProviderErrorCount<C> {
     type Target = C;
 
+    #[instrument(level = "trace")]
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/web3_proxy/src/metered/provider_error_count.rs
+++ b/web3_proxy/src/metered/provider_error_count.rs
@@ -46,7 +46,7 @@ impl<C: Counter + Debug, T: Debug> OnResult<Result<T, ProviderError>> for Provid
 }
 
 impl<C: Counter> Clear for ProviderErrorCount<C> {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn clear(&self) {
         self.0.clear()
     }
@@ -55,7 +55,7 @@ impl<C: Counter> Clear for ProviderErrorCount<C> {
 impl<C: Counter> Deref for ProviderErrorCount<C> {
     type Target = C;
 
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/web3_proxy/src/metrics_frontend.rs
+++ b/web3_proxy/src/metrics_frontend.rs
@@ -2,14 +2,14 @@ use axum::headers::HeaderName;
 use axum::http::HeaderValue;
 use axum::response::{IntoResponse, Response};
 use axum::{routing::get, Extension, Router};
-use tracing::info;
+use tracing::{info, instrument};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::app::Web3ProxyApp;
 
 /// Run a prometheus metrics server on the given port.
-
+#[instrument(level = "trace")]
 pub async fn serve(app: Arc<Web3ProxyApp>, port: u16) -> anyhow::Result<()> {
     // build our application with a route
     // order most to least common
@@ -42,6 +42,7 @@ pub async fn serve(app: Arc<Web3ProxyApp>, port: u16) -> anyhow::Result<()> {
         .map_err(Into::into)
 }
 
+#[instrument(level = "trace")]
 async fn root(Extension(app): Extension<Arc<Web3ProxyApp>>) -> Response {
     let serialized = app.prometheus_metrics().await;
 

--- a/web3_proxy/src/metrics_frontend.rs
+++ b/web3_proxy/src/metrics_frontend.rs
@@ -2,7 +2,7 @@ use axum::headers::HeaderName;
 use axum::http::HeaderValue;
 use axum::response::{IntoResponse, Response};
 use axum::{routing::get, Extension, Router};
-use log::info;
+use tracing::info;
 use std::net::SocketAddr;
 use std::sync::Arc;
 

--- a/web3_proxy/src/pagerduty.rs
+++ b/web3_proxy/src/pagerduty.rs
@@ -65,7 +65,7 @@ use tracing::{instrument};
 
 */
 
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(pagerduty_sync))]
 pub fn panic_handler(
     top_config: Option<TopConfig>,
     pagerduty_sync: &PagerdutySyncEventsV2,
@@ -115,7 +115,7 @@ pub fn panic_handler(
     }
 }
 
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(custom_details, severity))]
 pub fn pagerduty_alert_for_config<T: Serialize>(
     class: Option<String>,
     component: Option<String>,
@@ -143,7 +143,7 @@ pub fn pagerduty_alert_for_config<T: Serialize>(
     )
 }
 
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(custom_details, severity))]
 pub fn pagerduty_alert<T: Serialize>(
     chain_id: Option<u64>,
     class: Option<String>,

--- a/web3_proxy/src/pagerduty.rs
+++ b/web3_proxy/src/pagerduty.rs
@@ -10,6 +10,7 @@ use std::{
     panic::PanicInfo,
 };
 use time::OffsetDateTime;
+use tracing::{instrument};
 
 /*
 
@@ -64,6 +65,7 @@ use time::OffsetDateTime;
 
 */
 
+#[instrument(level = "trace")]
 pub fn panic_handler(
     top_config: Option<TopConfig>,
     pagerduty_sync: &PagerdutySyncEventsV2,
@@ -113,6 +115,7 @@ pub fn panic_handler(
     }
 }
 
+#[instrument(level = "trace")]
 pub fn pagerduty_alert_for_config<T: Serialize>(
     class: Option<String>,
     component: Option<String>,
@@ -140,6 +143,7 @@ pub fn pagerduty_alert_for_config<T: Serialize>(
     )
 }
 
+#[instrument(level = "trace")]
 pub fn pagerduty_alert<T: Serialize>(
     chain_id: Option<u64>,
     class: Option<String>,

--- a/web3_proxy/src/pagerduty.rs
+++ b/web3_proxy/src/pagerduty.rs
@@ -1,6 +1,6 @@
 use crate::config::TopConfig;
 use gethostname::gethostname;
-use log::{debug, error};
+use tracing::{debug, error};
 use pagerduty_rs::eventsv2sync::EventsV2 as PagerdutySyncEventsV2;
 use pagerduty_rs::types::{AlertTrigger, AlertTriggerPayload, Event};
 use serde::Serialize;

--- a/web3_proxy/src/rpcs/blockchain.rs
+++ b/web3_proxy/src/rpcs/blockchain.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use derive_more::From;
 use ethers::prelude::{Block, TxHash, H256, U64};
 use hashbrown::{HashMap, HashSet};
-use log::{debug, error, warn, Level};
+use tracing::{debug, error, warn, Level};
 use moka::future::Cache;
 use serde::Serialize;
 use serde_json::json;

--- a/web3_proxy/src/rpcs/blockchain.rs
+++ b/web3_proxy/src/rpcs/blockchain.rs
@@ -163,7 +163,7 @@ impl Web3Connections {
                 .request::<_, Option<_>>(
                     "eth_getBlockByHash",
                     &json!(get_block_params),
-                    Level::Error.into(),
+                    Level::ERROR.into(),
                 )
                 .await?
                 .context("no block!")?,

--- a/web3_proxy/src/rpcs/connection.rs
+++ b/web3_proxy/src/rpcs/connection.rs
@@ -10,7 +10,7 @@ use ethers::prelude::{Bytes, Middleware, ProviderError, TxHash, H256, U64};
 use ethers::types::U256;
 use futures::future::try_join_all;
 use futures::StreamExt;
-use log::{debug, error, info, trace, warn, Level};
+use tracing::{debug, error, info, trace, warn, Level};
 use migration::sea_orm::DatabaseConnection;
 use parking_lot::RwLock;
 use redis_rate_limiter::{RedisPool, RedisRateLimitResult, RedisRateLimiter};
@@ -352,12 +352,12 @@ impl Web3Connection {
             let retry_in = Duration::from_millis(sleep_ms);
 
             let error_level = if self.backup {
-                log::Level::Debug
+                tracing::Level::Debug
             } else {
-                log::Level::Info
+                tracing::Level::Info
             };
 
-            log::log!(
+            tracing::log!(
                 error_level,
                 "Failed reconnect to {}! Retry in {}ms. err={:?}",
                 self,

--- a/web3_proxy/src/rpcs/connection.rs
+++ b/web3_proxy/src/rpcs/connection.rs
@@ -102,7 +102,7 @@ impl Web3Connection {
     /// Connect to a web3 rpc
     // TODO: have this take a builder (which will have channels attached). or maybe just take the config and give the config public fields
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(hard_limit))]
     pub async fn spawn(
         name: String,
         display_name: Option<String>,
@@ -224,7 +224,7 @@ impl Web3Connection {
                 "eth_blockNumber",
                 &None,
                 // error here are expected, so keep the level low
-                Level::Debug.into(),
+                Level::DEBUG.into(),
             );
 
             let head_block_num = timeout(Duration::from_secs(5), head_block_num_future)
@@ -254,7 +254,7 @@ impl Web3Connection {
                         maybe_archive_block,
                     )),
                     // error here are expected, so keep the level low
-                    Level::Trace.into(),
+                    Level::TRACE.into(),
                 )
                 .await;
 
@@ -441,7 +441,7 @@ impl Web3Connection {
             .request(
                 "eth_chainId",
                 &json!(Option::None::<()>),
-                Level::Trace.into(),
+                Level::TRACE.into(),
             )
             .await;
         // trace!("found_chain_id: {:?}", found_chain_id);
@@ -732,7 +732,7 @@ impl Web3Connection {
                                     .request(
                                         "eth_getBlockByNumber",
                                         &json!(("latest", false)),
-                                        Level::Warn.into(),
+                                        Level::WARN.into(),
                                     )
                                     .await;
 
@@ -825,7 +825,7 @@ impl Web3Connection {
                         .request(
                             "eth_getBlockByNumber",
                             &json!(("latest", false)),
-                            Level::Warn.into(),
+                            Level::WARN.into(),
                         )
                         .await;
 
@@ -1085,7 +1085,7 @@ impl Web3Connection {
 }
 
 impl fmt::Debug for Web3Provider {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: the default Debug takes forever to write. this is too quiet though. we at least need the url
         f.debug_struct("Web3Provider").finish_non_exhaustive()
@@ -1093,7 +1093,7 @@ impl fmt::Debug for Web3Provider {
 }
 
 impl Hash for Web3Connection {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         // TODO: is this enough?
         self.name.hash(state);
@@ -1124,7 +1124,7 @@ impl PartialEq for Web3Connection {
 }
 
 impl Serialize for Web3Connection {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -1171,7 +1171,7 @@ impl Serialize for Web3Connection {
 }
 
 impl fmt::Debug for Web3Connection {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("Web3Connection");
 
@@ -1189,7 +1189,7 @@ impl fmt::Debug for Web3Connection {
 }
 
 impl fmt::Display for Web3Connection {
-    #[instrument(level = "trace")]
+    #[instrument(skip_all)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: filter basic auth and api keys
         write!(f, "{}", &self.name)

--- a/web3_proxy/src/rpcs/connections.rs
+++ b/web3_proxy/src/rpcs/connections.rs
@@ -58,7 +58,7 @@ pub struct Web3Connections {
 impl Web3Connections {
     /// Spawn durable connections to multiple Web3 providers.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(redis_pool))]
     pub async fn spawn(
         chain_id: u64,
         db_conn: Option<DatabaseConnection>,

--- a/web3_proxy/src/rpcs/connections.rs
+++ b/web3_proxy/src/rpcs/connections.rs
@@ -18,7 +18,7 @@ use futures::future::{join_all, try_join_all};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hashbrown::{HashMap, HashSet};
-use log::{debug, error, info, trace, warn, Level};
+use tracing::{debug, error, info, trace, warn, Level};
 use migration::sea_orm::DatabaseConnection;
 use moka::future::{Cache, ConcurrentCacheExt};
 use serde::ser::{SerializeStruct, Serializer};
@@ -1162,7 +1162,7 @@ mod tests {
         provider::Web3Provider,
     };
     use ethers::types::{Block, U256};
-    use log::{trace, LevelFilter};
+    use tracing::{trace, LevelFilter};
     use parking_lot::RwLock;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::RwLock as AsyncRwLock;

--- a/web3_proxy/src/rpcs/provider.rs
+++ b/web3_proxy/src/rpcs/provider.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use derive_more::From;
 use std::time::Duration;
+use tracing::{instrument};
 
 /// Use HTTP and WS providers.
 // TODO: instead of an enum, I tried to use Box<dyn Provider>, but hit <https://github.com/gakonst/ethers-rs/issues/592>
@@ -21,6 +22,7 @@ impl Web3Provider {
         }
     }
 
+    #[instrument(level = "trace")]
     pub async fn from_str(
         url_str: &str,
         http_client: Option<reqwest::Client>,

--- a/web3_proxy/src/rpcs/request.rs
+++ b/web3_proxy/src/rpcs/request.rs
@@ -8,7 +8,7 @@ use entities::revert_log;
 use entities::sea_orm_active_enums::Method;
 use ethers::providers::{HttpClientError, ProviderError, WsClientError};
 use ethers::types::{Address, Bytes};
-use log::{debug, error, trace, warn, Level};
+use tracing::{debug, error, trace, warn, Level};
 use metered::metered;
 use metered::HitCount;
 use metered::ResponseTime;

--- a/web3_proxy/src/rpcs/request.rs
+++ b/web3_proxy/src/rpcs/request.rs
@@ -71,10 +71,10 @@ impl From<Level> for RequestRevertHandler {
     #[instrument(level = "trace")]
     fn from(level: Level) -> Self {
         match level {
-            Level::Trace => RequestRevertHandler::TraceLevel,
-            Level::Debug => RequestRevertHandler::DebugLevel,
-            Level::Error => RequestRevertHandler::ErrorLevel,
-            Level::Warn => RequestRevertHandler::WarnLevel,
+            Level::TRACE => RequestRevertHandler::TraceLevel,
+            Level::DEBUG => RequestRevertHandler::DebugLevel,
+            Level::ERROR => RequestRevertHandler::ErrorLevel,
+            Level::WARN => RequestRevertHandler::WarnLevel,
             _ => unimplemented!("unexpected tracing Level"),
         }
     }

--- a/web3_proxy/src/rpcs/synced_connections.rs
+++ b/web3_proxy/src/rpcs/synced_connections.rs
@@ -5,6 +5,7 @@ use ethers::prelude::{H256, U64};
 use serde::Serialize;
 use std::fmt;
 use std::sync::Arc;
+use tracing::{instrument};
 
 /// A collection of Web3Connections that are on the same block.
 /// Serialize is so we can print it on our debug endpoint
@@ -20,10 +21,12 @@ pub struct ConsensusConnections {
 }
 
 impl ConsensusConnections {
+    #[instrument(level = "trace")]
     pub fn num_conns(&self) -> usize {
         self.conns.len()
     }
 
+    #[instrument(level = "trace")]
     pub fn sum_soft_limit(&self) -> u32 {
         self.conns.iter().fold(0, |sum, rpc| sum + rpc.soft_limit)
     }
@@ -32,6 +35,7 @@ impl ConsensusConnections {
 }
 
 impl fmt::Debug for ConsensusConnections {
+    #[instrument(skip_all)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: the default formatter takes forever to write. this is too quiet though
         // TODO: print the actual conns?
@@ -43,20 +47,24 @@ impl fmt::Debug for ConsensusConnections {
 }
 
 impl Web3Connections {
+    #[instrument(level = "trace")]
     pub fn head_block(&self) -> Option<ArcBlock> {
         self.watch_consensus_head_receiver
             .as_ref()
             .map(|x| x.borrow().clone())
     }
 
+    #[instrument(level = "trace")]
     pub fn head_block_hash(&self) -> Option<H256> {
         self.head_block().and_then(|x| x.hash)
     }
 
+    #[instrument(level = "trace")]
     pub fn head_block_num(&self) -> Option<U64> {
         self.head_block().and_then(|x| x.number)
     }
 
+    #[instrument(level = "trace")]
     pub fn synced(&self) -> bool {
         !self
             .watch_consensus_connections_sender
@@ -65,6 +73,7 @@ impl Web3Connections {
             .is_empty()
     }
 
+    #[instrument(level = "trace")]
     pub fn num_synced_rpcs(&self) -> usize {
         self.watch_consensus_connections_sender.borrow().conns.len()
     }

--- a/web3_proxy/src/rpcs/transactions.rs
+++ b/web3_proxy/src/rpcs/transactions.rs
@@ -5,7 +5,7 @@ use super::connection::Web3Connection;
 use super::connections::Web3Connections;
 use super::request::OpenRequestResult;
 use ethers::prelude::{ProviderError, Transaction, TxHash};
-use log::{debug, trace, Level};
+use tracing::{debug, trace, Level};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 

--- a/web3_proxy/src/rpcs/transactions.rs
+++ b/web3_proxy/src/rpcs/transactions.rs
@@ -36,7 +36,7 @@ impl Web3Connections {
                     .request(
                         "eth_getTransactionByHash",
                         &(pending_tx_id,),
-                        Level::Error.into(),
+                        Level::ERROR.into(),
                     )
                     .await?
             }

--- a/web3_proxy/src/rpcs/transactions.rs
+++ b/web3_proxy/src/rpcs/transactions.rs
@@ -5,12 +5,12 @@ use super::connection::Web3Connection;
 use super::connections::Web3Connections;
 use super::request::OpenRequestResult;
 use ethers::prelude::{ProviderError, Transaction, TxHash};
-use tracing::{debug, trace, Level};
+use tracing::{debug, instrument, trace, Level};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
 // TODO: think more about TxState
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum TxStatus {
     Pending(Transaction),
     Confirmed(Transaction),
@@ -18,6 +18,8 @@ pub enum TxStatus {
 }
 
 impl Web3Connections {
+
+    #[instrument(level = "trace")]
     async fn query_transaction_status(
         &self,
         authorization: &Arc<Authorization>,
@@ -63,6 +65,7 @@ impl Web3Connections {
     }
 
     /// dedupe transaction and send them to any listening clients
+    #[instrument(level = "trace")]
     pub(super) async fn process_incoming_tx_id(
         self: Arc<Self>,
         authorization: Arc<Authorization>,

--- a/web3_proxy/src/user_queries.rs
+++ b/web3_proxy/src/user_queries.rs
@@ -12,7 +12,7 @@ use chrono::{NaiveDateTime, Utc};
 use entities::{login, rpc_accounting, rpc_key};
 use hashbrown::HashMap;
 use http::StatusCode;
-use log::{debug, warn};
+use tracing::{debug, warn};
 use migration::sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
     QuerySelect, Select,

--- a/web3_proxy/src/user_queries.rs
+++ b/web3_proxy/src/user_queries.rs
@@ -26,7 +26,7 @@ use serde_json::json;
 /// First checks redis. Then checks the database.
 /// 0 means all users.
 /// This authenticates that the bearer is allowed to view this user_id's stats
-#[instrument(level = "trace")]
+#[instrument(level = "trace", skip(redis_conn))]
 pub async fn get_user_id_from_params(
     redis_conn: &mut RedisConnection,
     db_conn: &DatabaseConnection,

--- a/web3_proxy/src/user_queries.rs
+++ b/web3_proxy/src/user_queries.rs
@@ -12,7 +12,7 @@ use chrono::{NaiveDateTime, Utc};
 use entities::{login, rpc_accounting, rpc_key};
 use hashbrown::HashMap;
 use http::StatusCode;
-use tracing::{debug, warn};
+use tracing::{debug, instrument, warn};
 use migration::sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
     QuerySelect, Select,
@@ -26,6 +26,7 @@ use serde_json::json;
 /// First checks redis. Then checks the database.
 /// 0 means all users.
 /// This authenticates that the bearer is allowed to view this user_id's stats
+#[instrument(level = "trace")]
 pub async fn get_user_id_from_params(
     redis_conn: &mut RedisConnection,
     db_conn: &DatabaseConnection,
@@ -124,6 +125,7 @@ pub async fn get_user_id_from_params(
 /// this will keep people from reading someone else's keys.
 /// 0 means none.
 
+#[instrument(level = "trace")]
 pub fn get_rpc_key_id_from_params(
     user_id: u64,
     params: &HashMap<String, String>,
@@ -142,6 +144,7 @@ pub fn get_rpc_key_id_from_params(
     }
 }
 
+#[instrument(level = "trace")]
 pub fn get_chain_id_from_params(
     app: &Web3ProxyApp,
     params: &HashMap<String, String>,
@@ -156,6 +159,7 @@ pub fn get_chain_id_from_params(
     )
 }
 
+#[instrument(level = "trace")]
 pub fn get_query_start_from_params(
     params: &HashMap<String, String>,
 ) -> anyhow::Result<chrono::NaiveDateTime> {
@@ -179,6 +183,7 @@ pub fn get_query_start_from_params(
     )
 }
 
+#[instrument(level = "trace")]
 pub fn get_page_from_params(params: &HashMap<String, String>) -> anyhow::Result<u64> {
     params.get("page").map_or_else::<anyhow::Result<u64>, _, _>(
         || {
@@ -195,6 +200,7 @@ pub fn get_page_from_params(params: &HashMap<String, String>) -> anyhow::Result<
     )
 }
 
+#[instrument(level = "trace")]
 pub fn get_query_window_seconds_from_params(
     params: &HashMap<String, String>,
 ) -> Result<u64, FrontendErrorResponse> {
@@ -217,6 +223,7 @@ pub fn get_query_window_seconds_from_params(
     )
 }
 
+#[instrument(level = "trace")]
 pub fn filter_query_window_seconds(
     query_window_seconds: u64,
     response: &mut HashMap<&str, serde_json::Value>,
@@ -250,11 +257,13 @@ pub fn filter_query_window_seconds(
     Ok(q)
 }
 
+#[derive(Debug)]
 pub enum StatResponse {
     Aggregated,
     Detailed,
 }
 
+#[instrument(level = "trace")]
 pub async fn query_user_stats<'a>(
     app: &'a Web3ProxyApp,
     bearer: Option<TypedHeader<Authorization<Bearer>>>,

--- a/web3_proxy/src/user_token.rs
+++ b/web3_proxy/src/user_token.rs
@@ -4,23 +4,27 @@ use axum::headers::authorization::Bearer;
 use migration::sea_orm::prelude::Uuid;
 use serde::Serialize;
 use ulid::Ulid;
+use tracing::{instrument};
 
 /// Key used for caching the user's login
-#[derive(Clone, Hash, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct UserBearerToken(pub Ulid);
 
 impl UserBearerToken {
+    #[instrument(level = "trace")]
     pub fn redis_key(&self) -> String {
         format!("bearer:{}", self.0)
     }
 
+    #[instrument(level = "trace")]
     pub fn uuid(&self) -> Uuid {
         Uuid::from_u128(self.0.into())
     }
 }
 
 impl Default for UserBearerToken {
+    #[instrument(level = "trace")]
     fn default() -> Self {
         Self(Ulid::new())
     }
@@ -29,6 +33,7 @@ impl Default for UserBearerToken {
 impl FromStr for UserBearerToken {
     type Err = ulid::DecodeError;
 
+    #[instrument(level = "trace")]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ulid = Ulid::from_str(s)?;
 
@@ -37,12 +42,14 @@ impl FromStr for UserBearerToken {
 }
 
 impl From<Ulid> for UserBearerToken {
+    #[instrument(level = "trace")]
     fn from(x: Ulid) -> Self {
         Self(x)
     }
 }
 
 impl From<UserBearerToken> for Uuid {
+    #[instrument(level = "trace")]
     fn from(x: UserBearerToken) -> Self {
         x.uuid()
     }
@@ -51,6 +58,7 @@ impl From<UserBearerToken> for Uuid {
 impl TryFrom<Bearer> for UserBearerToken {
     type Error = ulid::DecodeError;
 
+    #[instrument(level = "trace")]
     fn try_from(b: Bearer) -> Result<Self, ulid::DecodeError> {
         let u = Ulid::from_string(b.token())?;
 


### PR DESCRIPTION
#22 
Oriented around: 
- 0e1cf5767c04eaa4cc9322a6c69506cff385ed28
- a534eae9684ccdac57c48ac3067b917114644dc2

- Added a bunch of `Debug` derives
- Check skip_all logic, especially for traits with strong generics
- will run rustfmt if files generally look ok (to order the imports mostly)