### PR TITLE
added some caching for influx queries, really fast provided same parameters

### DIFF
--- a/scripts/manual-tests/101-balance-referral-stats.sh
+++ b/scripts/manual-tests/101-balance-referral-stats.sh
@@ -133,4 +133,4 @@ curl \
 # Finally also get some stats
 curl -X GET \
 -H "Authorization: Bearer 01H2D5DN564M4Q2T6PETEZY83Q" \
-"http://localhost:8544/user/stats/detailed?query_start=1686236378&query_window_seconds=3600"
+"http://localhost:8544/user/stats/detailed?query_start=1686236378&query_window_seconds=3600&query_stop=1689236378"

--- a/web3_proxy/src/frontend/mod.rs
+++ b/web3_proxy/src/frontend/mod.rs
@@ -42,7 +42,7 @@ pub enum ResponseCacheKey {
 
 pub type ResponseCache = Cache<ResponseCacheKey, (StatusCode, &'static str, axum::body::Bytes)>;
 /// cache influxdb queries, because these are resource-intensive
-pub type InfluxResponseCache = Cache<u64, HashMap<String, serde_json::Value>>; // Turn this into a axum::body::Bytes
+pub type InfluxResponseCache = Cache<u64, axum::body::Bytes>; // Turn this into a axum::body::Bytes
 
 /// Start the frontend server.
 pub async fn serve(
@@ -65,7 +65,7 @@ pub async fn serve(
 
     // Move this to the mod.rs (frontend) server, this does not have to live inside the app
     // These responses are pretty large, so we will only save up to 1000 at a time. They can live for longer, however
-    let influx_cache: InfluxResponseCache = CacheBuilder::new(1_000)
+    let influx_cache: InfluxResponseCache = CacheBuilder::new(10_000)
         .name("influx_cache")
         .weigher(influx_response_weigher)
         .time_to_live(Duration::from_secs(3_600))

--- a/web3_proxy/src/frontend/mod.rs
+++ b/web3_proxy/src/frontend/mod.rs
@@ -65,7 +65,7 @@ pub async fn serve(
 
     // Move this to the mod.rs (frontend) server, this does not have to live inside the app
     // These responses are pretty large, so we will only save up to 1000 at a time. They can live for longer, however
-    let influx_cache: InfluxResponseCache = CacheBuilder::new(10_000)
+    let influx_cache: InfluxResponseCache = CacheBuilder::new(1_000_000)
         .name("influx_cache")
         .weigher(influx_response_weigher)
         .time_to_live(Duration::from_secs(3_600))

--- a/web3_proxy/src/frontend/users/stats.rs
+++ b/web3_proxy/src/frontend/users/stats.rs
@@ -1,6 +1,7 @@
 //! Handle registration, logins, and managing account data.
 use crate::app::Web3ProxyApp;
 use crate::errors::{Web3ProxyErrorContext, Web3ProxyResponse};
+use crate::frontend::InfluxResponseCache;
 use crate::http_params::{
     get_chain_id_from_params, get_page_from_params, get_query_start_from_params,
 };
@@ -126,10 +127,12 @@ pub async fn user_revert_logs_get(
 #[debug_handler]
 pub async fn user_stats_aggregated_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
+    Extension(influx_cache): Extension<Arc<InfluxResponseCache>>,
     bearer: Option<TypedHeader<Authorization<Bearer>>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Web3ProxyResponse {
-    let response = query_user_stats(&app, bearer, &params, StatType::Aggregated).await?;
+    let response =
+        query_user_stats(&app, &influx_cache, bearer, &params, StatType::Aggregated).await?;
 
     Ok(response)
 }
@@ -146,10 +149,12 @@ pub async fn user_stats_aggregated_get(
 #[debug_handler]
 pub async fn user_stats_detailed_get(
     Extension(app): Extension<Arc<Web3ProxyApp>>,
+    Extension(influx_cache): Extension<Arc<InfluxResponseCache>>,
     bearer: Option<TypedHeader<Authorization<Bearer>>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Web3ProxyResponse {
-    let response = query_user_stats(&app, bearer, &params, StatType::Detailed).await?;
+    let response =
+        query_user_stats(&app, &influx_cache, bearer, &params, StatType::Detailed).await?;
 
     Ok(response)
 }

--- a/web3_proxy/src/response_cache.rs
+++ b/web3_proxy/src/response_cache.rs
@@ -1,9 +1,14 @@
 use crate::{errors::Web3ProxyError, jsonrpc::JsonRpcErrorData, rpcs::blockchain::ArcBlock};
+use axum::body::Bytes;
 use derive_more::From;
 use ethers::{providers::ProviderError, types::U64};
 use hashbrown::hash_map::DefaultHashBuilder;
+use hashbrown::HashMap;
 use moka::future::Cache;
+use num_traits::AsPrimitive;
+use rdkafka::message::ToBytes;
 use serde_json::value::RawValue;
+use serde_json::Value;
 use std::{
     hash::{BuildHasher, Hash, Hasher},
     sync::Arc,
@@ -224,6 +229,11 @@ impl TryFrom<ProviderError> for JsonRpcErrorData {
             data,
         })
     }
+}
+
+// TODO: Change this to a axum::..::Bytes
+pub fn influx_response_weigher<K>(_key: &K, value: &HashMap<String, serde_json::Value>) -> u32 {
+    value.len() as u32
 }
 
 pub fn json_rpc_response_weigher<K, R>(_key: &K, value: &JsonRpcResponseEnum<R>) -> u32 {

--- a/web3_proxy/src/response_cache.rs
+++ b/web3_proxy/src/response_cache.rs
@@ -231,8 +231,7 @@ impl TryFrom<ProviderError> for JsonRpcErrorData {
     }
 }
 
-// TODO: Change this to a axum::..::Bytes
-pub fn influx_response_weigher<K>(_key: &K, value: &HashMap<String, serde_json::Value>) -> u32 {
+pub fn influx_response_weigher<K>(_key: &K, value: &axum::body::Bytes) -> u32 {
     value.len() as u32
 }
 

--- a/web3_proxy/src/stats/influxdb_queries.rs
+++ b/web3_proxy/src/stats/influxdb_queries.rs
@@ -174,6 +174,8 @@ pub async fn query_user_stats<'a>(
             user_rpc_keys
         )
     };
+
+    // We assume that the rpc-keys do not change that quickly
     // cache_key = cache_key
     //     .overflowing_add(keccak256(rpc_key_filter.to_bytes()).into())
     //     .0;
@@ -543,7 +545,6 @@ pub async fn query_user_stats<'a>(
 
     let response = Json(json!(response_body)).into_response();
 
-    // TODO: Add a cache for this response (and the corresponding input as well)
     // If we got here, we always want to update the cache (we'll never reach it twice though, unless the cache is too old)
     app.influx_cache.insert(cache_key, response_body).await;
 


### PR DESCRIPTION
@WyseNynja If the frontend makes the same query the cache should kick in. Specifically, if they round the intervals to the nearest 5 minutes (for example), caches should work well. I didn't constraint the cache further (division into daily, monthly, etc.), as this gives the frontend more flexibility to work with. 

Let me know if this is alongst the lines of what you imagined.

Optimally all parameters are set (no "defaults" are used, including query_start and query_stop), and any timestamps are clipped to the nearest 5-minute interval (depending on granularity)